### PR TITLE
Windows ScardTransmit fix

### DIFF
--- a/src/cardreader.cpp
+++ b/src/cardreader.cpp
@@ -532,7 +532,6 @@ void CardReader::DoTransmit(uv_work_t* req) {
     TransmitInput *ti = static_cast<TransmitInput*>(baton->input);
     CardReader* obj = baton->reader;
 
-    SCARD_IO_REQUEST io_request;
     TransmitResult *tr = new TransmitResult();
     tr->data = new unsigned char[ti->out_len];
     tr->len = ti->out_len;
@@ -541,10 +540,11 @@ void CardReader::DoTransmit(uv_work_t* req) {
     /* Lock mutex */
     uv_mutex_lock(&obj->m_mutex);
     /* Connected? */
+	// Under windows, SCARD_IO_REQUEST param must be NULL. Else error RPC_X_BAD_STUB_DATA / 0x06F7 on each call.
     if (obj->m_card_handle) {
         SCARD_IO_REQUEST send_pci = { ti->card_protocol, sizeof(SCARD_IO_REQUEST) };
         result = SCardTransmit(obj->m_card_handle, &send_pci, ti->in_data, ti->in_len,
-                               &io_request, tr->data, &tr->len);
+                               NULL, tr->data, &tr->len);
     }
 
     /* Unlock the mutex */

--- a/src/cardreader.cpp
+++ b/src/cardreader.cpp
@@ -540,7 +540,7 @@ void CardReader::DoTransmit(uv_work_t* req) {
     /* Lock mutex */
     uv_mutex_lock(&obj->m_mutex);
     /* Connected? */
-	// Under windows, SCARD_IO_REQUEST param must be NULL. Else error RPC_X_BAD_STUB_DATA / 0x06F7 on each call.
+    // Under windows, SCARD_IO_REQUEST param must be NULL. Else error RPC_X_BAD_STUB_DATA / 0x06F7 on each call.
     if (obj->m_card_handle) {
         SCARD_IO_REQUEST send_pci = { ti->card_protocol, sizeof(SCARD_IO_REQUEST) };
         result = SCardTransmit(obj->m_card_handle, &send_pci, ti->in_data, ti->in_len,


### PR DESCRIPTION
All calls to SCardTransmit fail on Windows.
We get error code: RPC_X_BAD_STUB_DATA / 0x06F7

To fix this we need to replace empty struct SCARD_IO_REQUEST pointer by NULL pointer on SCardTransmit call.

Call with NULL parameter was tested on Windows and MacOSX.