### PR TITLE
pkg: update description to use PC/SC

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "engines": {
         "node": ">=0.8.0 < 4"
     },
-    "description": "Bindings over pcsclite to access Smart Cards",
+    "description": "Bindings over PC/SC to access Smart Cards",
     "main": "index.js",
     "directories": {
         "test": "test"


### PR DESCRIPTION
Since version 0.4.0 of node-pcsclite all systems Linux, Mac OS X and
Windows are supported.
The wrapper is no more limited to pcsclite but to any implementation of
PC/SC.