### PR TITLE
Fix disconnect

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -16,7 +16,7 @@
 
 namespace {
 
-    std::string error_msg(const char* method, LONG result) {
+    std::string error_msg(const char* method, ULONG result) {
         char msg[ERR_MSG_MAX_LEN];
 #ifdef _WIN32
         LPVOID lpMsgBuf;
@@ -40,7 +40,7 @@ namespace {
 #else
         snprintf(msg,
                  ERR_MSG_MAX_LEN,
-                 "%s error: %s(0x%.8lx)",
+                 "%s error: %s(0x%.8ux)",
                  method,
                  pcsc_stringify_error(result),
                  result);

--- a/src/pcsclite.cpp
+++ b/src/pcsclite.cpp
@@ -28,7 +28,7 @@ PCSCLite::PCSCLite(): m_card_context(0),
     assert(uv_mutex_init(&m_mutex) == 0);
     assert(uv_cond_init(&m_cond) == 0);
 
-    LONG result = SCardEstablishContext(SCARD_SCOPE_SYSTEM,
+    ULONG result = SCardEstablishContext(SCARD_SCOPE_SYSTEM,
                                         NULL,
                                         NULL,
                                         &m_card_context);
@@ -154,7 +154,7 @@ void PCSCLite::HandleReaderStatusChange(uv_async_t *handle, int status) {
 
 void PCSCLite::HandlerFunction(void* arg) {
 
-    LONG result = SCARD_S_SUCCESS;
+    ULONG result = SCARD_S_SUCCESS;
     AsyncBaton* async_baton = static_cast<AsyncBaton*>(arg);
     PCSCLite* pcsclite = async_baton->pcsclite;
     async_baton->async_result = new AsyncResult();


### PR DESCRIPTION
Implement a new backoff timeout for SCardGetStatusChange to allow to read proper status changes from the reader.
This solves problems detecting a disconnect.
It's set to increment wait times from 10ms to 100ms until it stops in an INFINITE wait again.