### PR TITLE
Removed buffertools dependency

### DIFF
--- a/lib/pcsclite.js
+++ b/lib/pcsclite.js
@@ -1,5 +1,4 @@
 var events = require('events');
-var bt = require('buffertools');
 
 /* Make sure we choose the correct build directory */
 var bindings = require('bindings')('pcsclite');
@@ -12,7 +11,7 @@ var parse_readers_string = function(readers_str) {
     var pos;
     var readers = [];
     var ini = 0;
-    while ((pos = bt.indexOf(readers_str.slice(ini), '\0')) > 0) {
+    while ((pos = new Buffer(readers_str.slice(ini)).indexOf("\0")) > 0) {
         readers.push(readers_str.slice(ini, ini + pos).toString());
         ini += pos + 1;
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "test": "test"
     },
     "dependencies": {
-        "buffertools": "^2.1.2",
         "bindings": "^1.1.0",
         "nan": "^2.2.1"
     },


### PR DESCRIPTION
Buffertools are not needed anymore because of Node.js Buffer.