### PR TITLE
direct share protocol fix

### DIFF
--- a/lib/pcsclite.js
+++ b/lib/pcsclite.js
@@ -88,7 +88,7 @@ CardReader.prototype.connect = function(options, cb) {
 
     options = options || {};
     options.share_mode = options.share_mode || this.SCARD_SHARE_EXCLUSIVE;
-    
+
     if (typeof options.protocol === 'undefined' || options.protocol === null) {
         options.protocol = this.SCARD_PROTOCOL_T0 | this.SCARD_PROTOCOL_T1;
     }

--- a/lib/pcsclite.js
+++ b/lib/pcsclite.js
@@ -90,6 +90,10 @@ CardReader.prototype.connect = function(options, cb) {
     options.share_mode = options.share_mode || this.SCARD_SHARE_EXCLUSIVE;
     options.protocol = options.protocol || this.SCARD_PROTOCOL_T0 | this.SCARD_PROTOCOL_T1;
 
+    if (options.share_mode = this.SCARD_SHARE_DIRECT) {
+      options.protocol =  0;
+    }
+
     if (!this.connected) {
         this._connect(options.share_mode, options.protocol, cb);
     } else {

--- a/lib/pcsclite.js
+++ b/lib/pcsclite.js
@@ -88,10 +88,9 @@ CardReader.prototype.connect = function(options, cb) {
 
     options = options || {};
     options.share_mode = options.share_mode || this.SCARD_SHARE_EXCLUSIVE;
-    options.protocol = options.protocol || this.SCARD_PROTOCOL_T0 | this.SCARD_PROTOCOL_T1;
-
-    if (options.share_mode = this.SCARD_SHARE_DIRECT) {
-      options.protocol =  0;
+    
+    if (typeof options.protocol === 'undefined' || options.protocol === null) {
+        options.protocol = this.SCARD_PROTOCOL_T0 | this.SCARD_PROTOCOL_T1;
     }
 
     if (!this.connected) {


### PR DESCRIPTION
Hello,
according to two manuals (links below) when you use SCardConnect with SCARD_SHARE_DIRECT share mode, the protocol must be set to 0. 
Currently if 0 is passed to protocol, the librarary reverted to default values.

http://downloads.acs.com.hk/drivers/cn/PMA_ACR38x_v5.0.pdf
https://www.acs.com.hk/download-manual/1141/PMA_ACx30.pdf