### PR TITLE
added javascript implementation of SCARD_CTL_CODE define

### DIFF
--- a/lib/pcsclite.js
+++ b/lib/pcsclite.js
@@ -137,6 +137,15 @@ CardReader.prototype.control = function(data, control_code, res_len, cb) {
     });
 };
 
+CardReader.prototype.SCARD_CTL_CODE = function(code)  {
+    var isWin = /^win/.test(process.platform);
+    if (isWin) {
+        return (0x31 << 16 | (code) << 2);
+    } else {
+        return 0x42000000 + (code);
+    }
+};
+
 // extend prototype
 function inherits(target, source) {
     for (var k in source.prototype) {


### PR DESCRIPTION
This is an accessory function to SCardControl implementation. I think absolutely all examples on the internet use C implemenation of SCARD_CTL_CODE to get correct dwControlCode and it was missing from current implementation. 

I decided to name the function the same as its original C implementation.
