### PR TITLE
Expose list of readers via pcsclite.readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Emitted whenever a new card reader is detected.
 
 It frees the resources associated with this PCSCLite instance. At a low level it calls [`SCardCancel`](http://pcsclite.alioth.debian.org/pcsc-lite/node21.html) so it stops watching for new readers.
 
+#### pcsclite.readers
+
+An object containing all detected readers by name. Updated as readers are attached and removed.
 
 ### Class: CardReader
 

--- a/lib/pcsclite.js
+++ b/lib/pcsclite.js
@@ -33,6 +33,7 @@ module.exports = function() {
 
     var readers = {};
     var p = new PCSCLite();
+    p.readers = readers;
     process.nextTick(function() {
         p.start(function(err, data) {
             if (err) {


### PR DESCRIPTION
Resolves #77.

For our purposes, we cannot rely on a one-second tick timer to detect readers on-the-fly, and the tracking of readers is already done internally. Exposing this list is the simplest way for us (and others) to know exactly which readers are attached at any given moment.