### PR TITLE
Export interfaces and types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,18 @@
 import { EventEmitter } from "events";
 
-type ConnectOptions = {
+export type ConnectOptions = {
   share_mode?: number;
   protocol?: number;
 };
 
-type Status = {
+export type Status = {
   atr?: Buffer;
   state: number;
 };
 
 type AnyOrNothing = any | undefined | null;
 
-interface PCSCLite extends EventEmitter {
+export interface PCSCLite extends EventEmitter {
   on(type: "error", listener: (error: any) => void): this;
   once(type: "error", listener: (error: any) => void): this;
   on(type: "reader", listener: (reader: CardReader) => void): this;
@@ -20,7 +20,7 @@ interface PCSCLite extends EventEmitter {
   close(): void;
 }
 
-interface CardReader extends EventEmitter {
+export interface CardReader extends EventEmitter {
   // Share Mode
   SCARD_SHARE_SHARED: number;
   SCARD_SHARE_EXCLUSIVE: number;
@@ -87,6 +87,4 @@ interface CardReader extends EventEmitter {
   close(): void;
 }
 
-declare function pcsc(): PCSCLite;
-
-export = pcsc;
+export default function pcsc(): PCSCLite;


### PR DESCRIPTION
I've exported the types and interfaces. So they can be imported, and used within a project.

A reason for this, would be to type an array of CardReader. Which is one of my usecases, in this instance.

```typescript
import pcsc, { CardReader } from 'pcsclite'

const pcsclite = pcsc()
const readers: CardReader[] = []

pcsclite.on('reader', (reader) => {
  readers.push(reader)
})
```