### PR TITLE
Update example (remove Buffer deprecation warning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pcsc.on('reader', function(reader) {
                         console.log(err);
                     } else {
                         console.log('Protocol(', reader.name, '):', protocol);
-                        reader.transmit(new Buffer([0x00, 0xB0, 0x00, 0x00, 0x20]), 40, protocol, function(err, data) {
+                        reader.transmit(Buffer.from([0x00, 0xB0, 0x00, 0x00, 0x20]), 40, protocol, function(err, data) {
                             if (err) {
                                 console.log(err);
                             } else {


### PR DESCRIPTION
To remove this deprecation warning (`DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`) of the example, I replaced `new Buffer(…)` with `Buffer.from(…)`.