### PR TITLE
Use pkg-config to find libpcsclite if available

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,6 +18,9 @@
                         '/usr/include/PCSC',
                         '<!(node -e "require(\'nan\')")'
                     ],
+                    'cflags': [
+                        '<!@(command -v pkg-config && pkg-config --cflags libpcsclite || true)'
+                    ],
                     'link_settings': {
                         'libraries': [ '-lpcsclite' ],
                         'library_dirs': [ '/usr/lib' ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -19,7 +19,7 @@
                         '<!(node -e "require(\'nan\')")'
                     ],
                     'cflags': [
-                        '<!@(command -v pkg-config && pkg-config --cflags libpcsclite || true)'
+                        '<!@(command -v pkg-config &> /dev/null && pkg-config --cflags libpcsclite || true)'
                     ],
                     'link_settings': {
                         'libraries': [ '-lpcsclite' ],


### PR DESCRIPTION
Hello!

This patch uses pkg-config if available to determine the include path for libpcsclite. My headers are not installed in `/usr/include/PCSC`.

If there's a better way to delegate to pkg-config if available, please let me know!