### PR TITLE
Default protocol assignment fix

### DIFF
--- a/lib/pcsclite.js
+++ b/lib/pcsclite.js
@@ -93,7 +93,7 @@ CardReader.prototype.connect = function(options, cb) {
     options.share_mode = options.share_mode || this.SCARD_SHARE_EXCLUSIVE;
 
     if (typeof options.protocol === 'undefined' || options.protocol === null) {
-        options.protocol = this.SCARD_PROTOCOL_T0 | this.SCARD_PROTOCOL_T1;
+        options.protocol = this.SCARD_PROTOCOL_T0 || this.SCARD_PROTOCOL_T1;
     }
 
     if (!this.connected) {


### PR DESCRIPTION
When `connect` function is called without explicit protocol CardReader seems to work unstable.

Correct me if I'm wrong, but it looks like there should be logical OR, instead of binary OR.