### PR TITLE
Updates nan to v2.19.0 to fix updated signature ObjectTemplate::SetAccessor on v8 12+ (Electron 28+)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ type Status = {
 
 type AnyOrNothing = any | undefined | null;
 
-interface PCSCLite extends EventEmitter {
+export interface PCSCLite extends EventEmitter {
   on(type: "error", listener: (error: any) => void): this;
   once(type: "error", listener: (error: any) => void): this;
   on(type: "reader", listener: (reader: CardReader) => void): this;
@@ -20,7 +20,7 @@ interface PCSCLite extends EventEmitter {
   close(): void;
 }
 
-interface CardReader extends EventEmitter {
+export interface CardReader extends EventEmitter {
   // Share Mode
   SCARD_SHARE_SHARED: number;
   SCARD_SHARE_EXCLUSIVE: number;
@@ -89,4 +89,4 @@ interface CardReader extends EventEmitter {
 
 declare function pcsc(): PCSCLite;
 
-export = pcsc;
+export default pcsc;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "dependencies": {
         "bindings": "^1.1.0",
-        "nan": "^2.14.0"
+        "nan": "^2.19.0"
     },
     "devDependencies": {
         "mocha": "~1.11.0",


### PR DESCRIPTION
Updates nan to v2.19.0 to fix updated signature ObjectTemplate::SetAccessor on v8 12+ (Electron 28+)